### PR TITLE
Cross sectoral standard

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -20,10 +20,3 @@ repos:
     rev: 5.12.0
     hooks:
     -   id: isort
-- repo: local
-  hooks:
-    - id: pylint
-      name: pylint
-      entry: pylint
-      language: system
-      types: [python]

--- a/pathfinder_network/datamodel/cross_sectoral_standard.py
+++ b/pathfinder_network/datamodel/cross_sectoral_standard.py
@@ -1,0 +1,15 @@
+from enum import Enum
+
+
+class CrossSectoralStandard(str, Enum):
+    """
+    CrossSectoralStandard is the enumeration of accounting standards used for product carbon footprint calculation.
+    Valid values are:
+    - GHG Protocol Product standard: for the GHG Protocol Product standard
+    - ISO Standard 14067: for ISO Standard 14067
+    - ISO Standard 14044: for ISO Standard 14044
+    """
+
+    GHG_PROTOCOL = "GHG Protocol Product standard"
+    ISO_STANDARD_14067 = "ISO Standard 14067"
+    ISO_STANDARD_14044 = "ISO Standard 14044"

--- a/pathfinder_network/datamodel/cross_sectoral_standard_set.py
+++ b/pathfinder_network/datamodel/cross_sectoral_standard_set.py
@@ -1,0 +1,25 @@
+from pydantic import BaseModel, validator
+
+from pathfinder_network.datamodel.cross_sectoral_standard import CrossSectoralStandard
+
+
+class CrossSectoralStandardSet(BaseModel):
+    """
+    A set of CrossSectoralStandards of size 1 or larger.
+
+    Attributes:
+        standards (list[CrossSectoralStandard]): A list of CrossSectoralStandard objects.
+
+    Raises:
+        ValueError: If the list of standards is empty.
+    """
+
+    standards: list[CrossSectoralStandard]
+
+    @validator("standards")
+    def check_rules(cls, v: list[CrossSectoralStandard]) -> list[CrossSectoralStandard]:
+        if len(v) < 1:
+            raise ValueError(
+                "CrossSectoralStandardSet must contain at least one CrossSectoralStandard"
+            )
+        return v

--- a/tests/datamodel/test_cross_sectoral_standard.py
+++ b/tests/datamodel/test_cross_sectoral_standard.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pathfinder_network.datamodel.cross_sectoral_standard import CrossSectoralStandard
+
+
+def test_valid_cross_sectoral_standards():
+    valid_cs_standards = [
+        "GHG Protocol Product standard",
+        "ISO Standard 14067",
+        "ISO Standard 14044",
+    ]
+    for cs_standard in valid_cs_standards:
+        assert CrossSectoralStandard(cs_standard).value == cs_standard
+
+
+def test_cross_sectoral_standards_values():
+    assert CrossSectoralStandard.GHG_PROTOCOL == "GHG Protocol Product standard"
+    assert CrossSectoralStandard.ISO_STANDARD_14067 == "ISO Standard 14067"
+    assert CrossSectoralStandard.ISO_STANDARD_14044 == "ISO Standard 14044"
+
+
+def test_invalid_cross_sectoral_standard():
+    with pytest.raises(ValueError):
+        CrossSectoralStandard("invalid unit")

--- a/tests/datamodel/test_cross_sectoral_standard_set.py
+++ b/tests/datamodel/test_cross_sectoral_standard_set.py
@@ -1,0 +1,26 @@
+import pytest
+
+from pathfinder_network.datamodel.cross_sectoral_standard import CrossSectoralStandard
+from pathfinder_network.datamodel.cross_sectoral_standard_set import (
+    CrossSectoralStandardSet,
+)
+
+
+@pytest.fixture
+def valid_cross_sectoral_standard():
+    standard = CrossSectoralStandard.ISO_STANDARD_14067
+
+    return standard
+
+
+def test_cross_sectoral_standard_set_with_valid_standard(valid_cross_sectoral_standard):
+    csc_set = CrossSectoralStandardSet(standards=[valid_cross_sectoral_standard])
+    assert csc_set.standards
+
+
+def test_cross_sectoral_standard_set_with_empty_list():
+    with pytest.raises(
+        ValueError,
+        match="CrossSectoralStandardSet must contain at least one CrossSectoralStandard",
+    ):
+        CrossSectoralStandardSet(standards=[])


### PR DESCRIPTION
Implement the following datatypes from the spec:

- 4.9. Data Type: CrossSectoralStandard - https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/#dt-crosssectoralstandard
- 4.10. Data Type: CrossSectoralStandardSet - https://wbcsd.github.io/tr/2023/data-exchange-protocol-20230221/#dt-crosssectoralstandardset

Also:

- Remove `pylint` from the `pre-commit-config.yaml` file for the time being, didn't have enough time to fix errors, come back when core spec actions are implemented and fix lint errors.