### PR TITLE
Assurance datatype

### DIFF
--- a/pathfinder_network/datamodel/assurance.py
+++ b/pathfinder_network/datamodel/assurance.py
@@ -1,0 +1,23 @@
+from datetime import datetime
+from enum import Enum
+
+from pydantic import BaseModel
+
+from pathfinder_network.datamodel.non_empty_string import NonEmptyString
+
+
+class AssuranceCoverage(str, Enum):
+    corporate_level = "corporate level"
+    product_line = "product line"
+    pcf_system = "PCF system"
+    product_level = "product level"
+
+
+class AssuranceLevel(str, Enum):
+    limited = "limited"
+    reasonable = "reasonable"
+
+
+class AssuranceBoundary(str, Enum):
+    gate_to_gate = "Gate-to-Gate"
+    cradle_to_gate = "Cradle-to-Gate"

--- a/pathfinder_network/datamodel/assurance.py
+++ b/pathfinder_network/datamodel/assurance.py
@@ -30,6 +30,33 @@ class Assurance(BaseModel):
     Attributes:
     - assurance (bool): Binary indicator stating whether the PCF has been assured in line with
     Pathfinder Framework requirements
+    - coverage (str): Level of granularity of the emissions data assured. Valid values are:
+        - "corporate level" for corporate level
+        - "product line" for product line
+        - "PCF system" for PCF System
+        - "product level" for product level
+        This property MAY be undefined only if the kind of assurance was not performed.
+    - level (str): Level of assurance applicable to the PCF. Valid values are:
+        - "limited" for limited assurance
+        - "reasonable" for reasonable assurance
+        This property is optional.
+    - boundary (str): Boundary of the assurance. Valid values are:
+        - "Gate-to-Gate" for Gate-to-Gate
+        - "Cradle-to-Gate" for Cradle-to-Gate
+        This property is optional.
+    - providerName (str): The non-empty name of the independent third party engaged to undertake the assurance.
+        This property is required.
+    - completedAt (datetime): The date at which the assurance was completed. This property is optional.
+    - standardName (str): Name of the standard against which the PCF was assured. This property is optional.
+    - comments (str): Any additional comments that will clarify the interpretation of the assurance.
+        This property may be an empty string. This property is optional.
     """
 
     assurance: bool
+    coverage: AssuranceCoverage | None = None
+    level: AssuranceLevel | None = None
+    boundary: AssuranceBoundary | None = None
+    providerName: NonEmptyString | None = None
+    completedAt: datetime | None = None
+    standardName: str | None = None
+    comments: str | None = None

--- a/pathfinder_network/datamodel/assurance.py
+++ b/pathfinder_network/datamodel/assurance.py
@@ -21,3 +21,15 @@ class AssuranceLevel(str, Enum):
 class AssuranceBoundary(str, Enum):
     gate_to_gate = "Gate-to-Gate"
     cradle_to_gate = "Cradle-to-Gate"
+
+
+class Assurance(BaseModel):
+    """
+    Data type Assurance contains the assurance in conformance with Pathfinder Framework chapter 5 and appendix B.
+
+    Attributes:
+    - assurance (bool): Binary indicator stating whether the PCF has been assured in line with
+    Pathfinder Framework requirements
+    """
+
+    assurance: bool

--- a/tests/datamodel/test_assurance.py
+++ b/tests/datamodel/test_assurance.py
@@ -1,6 +1,7 @@
 import pytest
 
 from pathfinder_network.datamodel.assurance import (
+    Assurance,
     AssuranceBoundary,
     AssuranceCoverage,
     AssuranceLevel,
@@ -40,3 +41,9 @@ def test_level_enum(input_value, expected_output):
 )
 def test_boundary_enum(input_value, expected_output):
     assert AssuranceBoundary(input_value) == expected_output
+
+
+def test_valid_assurance():
+    assurance = Assurance(assurance=True)
+
+    assert assurance.assurance is True

--- a/tests/datamodel/test_assurance.py
+++ b/tests/datamodel/test_assurance.py
@@ -1,0 +1,42 @@
+import pytest
+
+from pathfinder_network.datamodel.assurance import (
+    AssuranceBoundary,
+    AssuranceCoverage,
+    AssuranceLevel,
+)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        ("corporate level", AssuranceCoverage.corporate_level),
+        ("product line", AssuranceCoverage.product_line),
+        ("PCF system", AssuranceCoverage.pcf_system),
+        ("product level", AssuranceCoverage.product_level),
+    ],
+)
+def test_coverage_enum(input_value, expected_output):
+    assert AssuranceCoverage(input_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        ("limited", AssuranceLevel.limited),
+        ("reasonable", AssuranceLevel.reasonable),
+    ],
+)
+def test_level_enum(input_value, expected_output):
+    assert AssuranceLevel(input_value) == expected_output
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output",
+    [
+        ("Gate-to-Gate", AssuranceBoundary.gate_to_gate),
+        ("Cradle-to-Gate", AssuranceBoundary.cradle_to_gate),
+    ],
+)
+def test_boundary_enum(input_value, expected_output):
+    assert AssuranceBoundary(input_value) == expected_output

--- a/tests/datamodel/test_assurance.py
+++ b/tests/datamodel/test_assurance.py
@@ -47,3 +47,17 @@ def test_valid_assurance():
     assurance = Assurance(assurance=True)
 
     assert assurance.assurance is True
+
+
+def test_valid_assurance_with_enums():
+    assurance = Assurance(
+        assurance=True,
+        coverage=AssuranceCoverage.corporate_level,
+        level=AssuranceLevel.limited,
+        boundary=AssuranceBoundary.gate_to_gate,
+    )
+
+    assert assurance.assurance is True
+    assert assurance.coverage == "corporate level"
+    assert assurance.level == "limited"
+    assert assurance.boundary == "Gate-to-Gate"


### PR DESCRIPTION
Implements the following datatype, reasonably to spec, as the spec for this datatype is moving around a bit:

https://wbcsd.github.io/data-exchange-protocol/v2/#dt-assurance

This PR actually contains some stuff that's more in line with the Pathfinder Framework's spec.

